### PR TITLE
Allow unset Faraday response type for new client

### DIFF
--- a/examples/bitstream_content.rb
+++ b/examples/bitstream_content.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "dspace/client"
+
+config = DSpace::Configuration.new(settings: {
+  rest_url: ENV.fetch("DSPACE_CLIENT_REST_URL"),
+  username: ENV.fetch("DSPACE_CLIENT_USERNAME"),
+  password: ENV.fetch("DSPACE_CLIENT_PASSWORD")
+})
+client = DSpace::Client.new(config: config)
+client.login
+
+bitstream = client.bitstreams.retrieve(uuid: "c427c2f9-a500-4e04-8427-6e7c899fe66b")
+puts bitstream.content

--- a/lib/dspace/client/client.rb
+++ b/lib/dspace/client/client.rb
@@ -6,10 +6,11 @@ module DSpace
     attr_accessor :authorization, :token
     attr_reader :config
 
-    def initialize(config:)
+    def initialize(config:, response: :json)
       @authorization = nil
       @config = config
       @token = nil
+      @response = response
     end
 
     # Expose basic operations: (get, post, put, delete)
@@ -93,7 +94,7 @@ module DSpace
         conn.use :cookie_jar
 
         conn.request :json
-        conn.response :json
+        conn.response @response if @response
       end
     end
   end

--- a/lib/dspace/client/objects/bitstream.rb
+++ b/lib/dspace/client/objects/bitstream.rb
@@ -2,8 +2,16 @@
 
 module DSpace
   class Bitstream < Object
-    def content
-      DSpace::Request.new(client: client).get_request("server/api/core/bitstreams/#{uuid}/content").body
+    def content(headers = {})
+      # awkward, but we need to create a new client to get the bitstream content
+      # to suppress the otherwise very convenient :json response type
+      bitstream_client = DSpace::Client.new(config: client.config, response: nil)
+      bitstream_client.login
+
+      DSpace::Request.new(client: bitstream_client).get_request(
+        "server/api/core/bitstreams/#{uuid}/content",
+        headers: headers
+      ).body
     end
   end
 end


### PR DESCRIPTION
This facilitates bitstream downloads for non-json data types.